### PR TITLE
Update browser support requirements

### DIFF
--- a/docs/component-spec/modules.md
+++ b/docs/component-spec/modules.md
@@ -300,9 +300,18 @@ Modules that are not openly published on GitHub *should* use Jenkins for CI.
 
 ## Browser support
 
-All modules *must* be tested with all the browsers [listed in the FT browser support policy](https://docs.google.com/a/ft.com/document/d/1dX92MPm9ZNY2jqFidWf_E6V4S6pLkydjcPmk5F989YI/edit#heading=h.wcrwnubj26sk), and if a module includes JavaScript, it must be error free in all the browsers that fall above the recommended minimum boundary for enhanced experience in that policy.
+All modules *must* be tested with the following browsers:
 
-The versions tested *should* be listed in the module's documentation, so that when boundary recommendations are changed, it is still possible to determine the support that was designed into an older module.
+- IE9
+- IE10
+- IE11
+- Chrome
+- Firefox
+- Safari
+- Chrome (Android)
+- Mobile Safari
+
+Modules *should* note in the readme any exceptions to the support policy.
 
 ## Where to store modules
 


### PR DESCRIPTION
@dlamp and @aamirali1: Starting with the _de facto_ list that we have been supporting in the initial components, which will more than cover our current products. I'm recommending that a browser support statement not be included in component readme files, unless there is an exception.

Issue #9